### PR TITLE
Open the mail app on the compose screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,20 +47,22 @@ Omitting these might mean that the library can't detect some of the mail apps in
 
 ## Usage
 
-```
+### openInbox
+
+```javascript
 import { openInbox } from 'react-native-email-link'
 
 openInbox()
 ```
 
-## Arguments
+#### Arguments
 
 - [`title`](#title)
 - [`message`](#message)
 - [`cancelLabel`](#cancelLabel)
 - [`removeText`](#removeText)
 
-### `title`
+#### `title`
 
 Text for the top of the ActionSheet or Intent.
 
@@ -68,7 +70,7 @@ Text for the top of the ActionSheet or Intent.
 | -------- | -------- | --------------- |
 | string   | No       | 'Open mail app' |
 
-### `message`
+#### `message`
 
 Subtext under the title on the ActionSheet
 
@@ -76,7 +78,7 @@ Subtext under the title on the ActionSheet
 | -------- | -------- | ----------------------------------- | -------- |
 | string   | No       | 'Which app would you like to open?' | iOS      |
 
-### `cancelLabel`
+#### `cancelLabel`
 
 Text for last button of the ActionSheet.
 
@@ -84,7 +86,7 @@ Text for last button of the ActionSheet.
 | -------- | -------- | --------- | -------- |
 | string   | No       | 'Cancel'  | iOS      |
 
-### `removeText`
+#### `removeText`
 
 If true, not text will be show above the ActionSheet or Intent. Default value is false.
 
@@ -92,6 +94,97 @@ If true, not text will be show above the ActionSheet or Intent. Default value is
 | -------- | -------- | -------- |
 | boolean  | No       | false    |
 
+### openComposer
+
+```javascript
+import { openComposer } from 'react-native-email-link'
+
+openComposer()
+```
+
+#### Arguments
+
+- [`title`](#title)
+- [`message`](#message)
+- [`cancelLabel`](#cancelLabel)
+- [`removeText`](#removeText)
+- [`to`](#to)
+- [`cc`](#cc)
+- [`bcc`](#bcc)
+- [`subject`](#subject)
+- [`body`](#body)
+
+#### `title`
+
+Text for the top of the ActionSheet or Intent.
+
+| Type     | Required | Default         |
+| -------- | -------- | --------------- |
+| string   | No       | 'Open mail app' |
+
+#### `message`
+
+Subtext under the title on the ActionSheet.
+
+| Type     | Required | Default                             | Platform |
+| -------- | -------- | ----------------------------------- | -------- |
+| string   | No       | 'Which app would you like to open?' | iOS      |
+
+#### `cancelLabel`
+
+Text for last button of the ActionSheet.
+
+| Type     | Required | Default   | Platform |
+| -------- | -------- | --------- | -------- |
+| string   | No       | 'Cancel'  | iOS      |
+
+#### `removeText`
+
+If true, not text will be show above the ActionSheet or Intent. Default value is false.
+
+| Type     | Required | Default  |
+| -------- | -------- | -------- |
+| boolean  | No       | false    |
+
+#### `to`
+
+Recipient's email address.
+
+| Type     | Required | Default  |
+| -------- | -------- | -------- |
+| string   | No       | null     |
+
+#### `cc`
+
+Email's cc.
+
+| Type     | Required | Default  |
+| -------- | -------- | -------- |
+| string   | No       | null     |
+
+#### `bcc`
+
+Email's bcc.
+
+| Type     | Required | Default  |
+| -------- | -------- | -------- |
+| string   | No       | null     |
+
+#### `subject`
+
+Email's subject.
+
+| Type     | Required | Default  |
+| -------- | -------- | -------- |
+| string   | No       | null     |
+
+#### `body`
+
+Email's body.
+
+| Type     | Required | Default  |
+| -------- | -------- | -------- |
+| string   | No       | null     |
 
 ## Authors
 
@@ -101,3 +194,4 @@ company like no other.
 Contributors:
 
 * Thomas Schoffelen, [@tschoffelen](https://twitter.com/tschoffelen)
+* César Jeanroy, [@cesar3030](https://github.com/cesar3030)

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ If true, not text will be show above the ActionSheet or Intent. Default value is
 
 ### openComposer
 
+**Note**: `openComposer()` is only available for iOS. If used with an android device, it will behave exaclty like `openInbox()`. (PRs are welcomed to add Android support)
+
 ```javascript
 import { openComposer } from 'react-native-email-link'
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,3 +11,27 @@ export function openInbox({
   cancelLabel?: string;
   removeText?: boolean;
 }): void;
+
+export function openCompose({
+  app,
+  title,
+  message,
+  cancelLabel,
+  removeText,
+  to,
+  cc,
+  bcc,
+  subject,
+  body,
+}: {
+  app?: string | null;
+  title?: string;
+  message?: string;
+  cancelLabel?: string;
+  removeText?: boolean;
+  to?: string;
+  cc?: string;
+  bcc?: string;
+  subject?: string;
+  body?: string;
+}): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,3 +35,8 @@ export function openComposer({
   subject?: string;
   body?: string;
 }): void;
+
+export class EmailException {
+  message: string;
+  name: string;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ export function openInbox({
   removeText?: boolean;
 }): void;
 
-export function openCompose({
+export function openComposer({
   app,
   title,
   message,

--- a/index.ios.js
+++ b/index.ios.js
@@ -37,13 +37,13 @@ const titles = {
 };
 
 /**
- * Available params for each app url
+ * Allowed params for each app url
  *  - apple-mail: https://ios.gadgethacks.com/news/always-updated-list-ios-app-url-scheme-names-0184033/
  *  - gmail: https://stackoverflow.com/questions/32114455/open-gmail-app-from-my-app 
+ *  - inbox: https://stackoverflow.com/questions/29655978/is-there-an-ios-mail-scheme-url-for-googles-inbox
  *  - spark: https://helpspot.readdle.com/spark/index.php?pg=kb.page&id=791
  *  - airmail: https://help.airmailapp.com/en-us/article/airmail-ios-url-scheme-1q060gy/
  *  - outlook: https://stackoverflow.com/questions/32369198/i-just-want-to-open-ms-outlook-app-and-see-mailto-screen-using-url-scheme-at-ios
- * 
  */
 const uriParams = {
   "apple-mail": {
@@ -53,6 +53,14 @@ const uriParams = {
     body: 'body'
   },
   gmail: {
+    path: 'co',
+    to: 'to',
+    cc: 'cc',
+    bcc: 'bcc',
+    subject: 'subject',
+    body: 'body'
+  },
+  inbox: {
     path: 'co',
     to: 'to',
     cc: 'cc',
@@ -103,7 +111,7 @@ function getUrlParams(app, options) {
     return params;
   }, [])
   
-  const path = app === 'apple-mail' ? options['to'] : appParms['path'];
+  const path = app === 'apple-mail' ? (options['to'] || '') : appParms['path'];
   return `${path}?${urlParams.join('&')}`
 }
 
@@ -219,7 +227,7 @@ export async function openInbox(options = {}) {
   }
 
   let params = '';
-  if(options.to || options.subject || options.body) {
+  if(options.to || options.subject || options.body || options.cc || options.bcc) {
     params = getUrlParams(app, options);
 
     if (app === 'apple-mail') {

--- a/index.ios.js
+++ b/index.ios.js
@@ -257,8 +257,7 @@ export async function openInbox(options) {
   *     cc: string,
   *     bcc: string,
   *     subject: string,
-  *     body: string,
-  *     compose: boolean
+  *     body: string
   * }} options
   */
 export async function openComposer(options) {

--- a/index.ios.js
+++ b/index.ios.js
@@ -4,7 +4,7 @@
  * This file supports both iOS and Android.
  */
 
-import { ActionSheetIOS, Alert, Linking } from "react-native";
+import { ActionSheetIOS, Linking } from "react-native";
 import { option } from "@oclif/parser/lib/flags";
 
 class EmailException {
@@ -96,23 +96,25 @@ const uriParams = {
  * @param {string} app 
  * @param {{
  *     to: string,
+ *     cc: string,
+ *     bcc: string,
  *     subject: string,
- *     body: string
+ *     body: string,
  * }} options 
  */
 function getUrlParams(app, options) {
   const appParms = uriParams[app];
   if (!appParms) { return "" };
 
+  const path = app === 'apple-mail' ? (options['to'] || '') : appParms['path'];
   const urlParams = Object.keys(appParms).reduce((params, currentParam) => {
     if (options[currentParam]) {
       params.push(`${appParms[currentParam]}=${options[currentParam]}`);
     }
     return params;
-  }, [])
-  
-  const path = app === 'apple-mail' ? (options['to'] || '') : appParms['path'];
-  return `${path}?${urlParams.join('&')}`
+  }, []);
+
+  return `${path}?${urlParams.join('&')}`;
 }
 
 /**
@@ -193,9 +195,15 @@ export function askAppChoice(
  *     message: string,
  *     cancelLabel: string,
  *     removeText: boolean,
+ *     to: string,
+ *     cc: string,
+ *     bcc: string,
+ *     subject: string,
+ *     body: string,
+ *     compose: boolean
  * }} options
  */
-export async function openInbox(options = {}) {
+export async function openInbox(options = { compose = false }) {
   if (!options || typeof options !== "object") {
     throw new EmailException(
       "First parameter of `openInbox` should contain object with options."
@@ -227,7 +235,7 @@ export async function openInbox(options = {}) {
   }
 
   let params = '';
-  if(options.to || options.subject || options.body || options.cc || options.bcc) {
+  if(option.compose || options.to || options.subject || options.body || options.cc || options.bcc) {
     params = getUrlParams(app, options);
 
     if (app === 'apple-mail') {

--- a/index.ios.js
+++ b/index.ios.js
@@ -71,6 +71,8 @@ const uriParams = {
   spark: {
     path: 'compose',
     to: 'recipient',
+    cc: 'cc',
+    bcc: 'bcc',
     subject: 'subject',
     body: 'body'
   },
@@ -85,6 +87,8 @@ const uriParams = {
   outlook: {
     path: 'compose',
     to: 'to',
+    cc: 'cc',
+    bcc: 'bcc',
     subject: 'subject',
     body: 'body'
   },
@@ -187,9 +191,9 @@ export function askAppChoice(
 
 /**
  * Returns the name of the app provided in the options object of the app selected by the user.
- * @param {
+ * @param {{
  *     app: string | undefined | null,
- * } options 
+ * }} options 
  */
 async function getApp(options) {
   if (

--- a/index.ios.js
+++ b/index.ios.js
@@ -5,6 +5,7 @@
  */
 
 import { ActionSheetIOS, Alert, Linking } from "react-native";
+import { option } from "@oclif/parser/lib/flags";
 
 class EmailException {
   constructor(message) {
@@ -34,6 +35,38 @@ const titles = {
   yahoo: "Yahoo Mail",
   superhuman: "Superhuman"
 };
+
+const uriParams = {
+  gmail: {
+    path: 'co',
+    to: 'to',
+    subject: 'subject',
+    body: 'body'
+  }
+}
+
+/**
+ * Returns param to open app compose screen and pre-fill 'to', 'subject' and 'body',
+ * @param {string} app 
+ * @param {{
+ *     to: string,
+ *     subject: string,
+ *     body: string
+ * }} options 
+ */
+function getUrlParams(app, options) {
+  const appParms = uriParams[app];
+  if (!appParms) { return "" };
+
+  const urlParams = ['to', 'subject', 'body'].reduce((params, currentParam) => {
+    if (options[currentParam]) {
+      params.push(`${appParms[currentParam]}=${options[currentParam]}`);
+    }
+    return params;
+  }, [])
+  
+  return `${appParms['path']}?${urlParams.join('&')}`
+}
 
 /**
  * Check if a given mail app is installed.
@@ -77,7 +110,9 @@ export function askAppChoice(
         availableApps.push(app);
       }
     }
+    console.log('availableApps: ', availableApps);
     if (availableApps.length < 2) {
+      console.log()
       return resolve(availableApps[0] || null);
     }
 
@@ -144,7 +179,12 @@ export async function openInbox(options = {}) {
       url = prefixes[app];
   }
 
+  let params = '';
+  if(options.to || options.subject || options.body) {
+    params = getUrlParams(app, options);
+  }
+
   if (url) {
-    return Linking.openURL(url);
+    return Linking.openURL(`${url}${params}`);
   }
 }

--- a/index.ios.js
+++ b/index.ios.js
@@ -196,6 +196,12 @@ export function askAppChoice(
  * }} options 
  */
 async function getApp(options) {
+  if (options && typeof options !== "object") {
+    throw new EmailException(
+      "First parameter must be an object of options."
+    );
+  }
+
   if (
     "app" in options &&
     options.app &&
@@ -234,12 +240,6 @@ async function getApp(options) {
   * }} options
   */
 export async function openInbox(options) {
-  if (!options || typeof options !== "object") {
-    throw new EmailException(
-      "First parameter of `openInbox` should contain object with options."
-    );
-  }
-
   const app = await getApp(options);
   return Linking.openURL(prefixes[app]);
 }
@@ -261,12 +261,6 @@ export async function openInbox(options) {
   * }} options
   */
 export async function openComposer(options) {
-  if (!options || typeof options !== "object") {
-    throw new EmailException(
-      "First parameter of `openComposer` should contain object with options."
-    );
-  }
-
   const app = await getApp(options);
   const params = getUrlParams(app, options);
   let prefix = prefixes[app];

--- a/index.ios.js
+++ b/index.ios.js
@@ -38,15 +38,31 @@ const titles = {
 
 /**
  * Available params for each app url
- *  - airmail: https://help.airmailapp.com/en-us/article/airmail-ios-url-scheme-1q060gy/
+ *  - apple-mail: https://ios.gadgethacks.com/news/always-updated-list-ios-app-url-scheme-names-0184033/
  *  - gmail: https://stackoverflow.com/questions/32114455/open-gmail-app-from-my-app 
+ *  - spark: https://helpspot.readdle.com/spark/index.php?pg=kb.page&id=791
+ *  - airmail: https://help.airmailapp.com/en-us/article/airmail-ios-url-scheme-1q060gy/
+ *  - outlook: https://stackoverflow.com/questions/32369198/i-just-want-to-open-ms-outlook-app-and-see-mailto-screen-using-url-scheme-at-ios
+ * 
  */
 const uriParams = {
+  "apple-mail": {
+    cc: 'cc',
+    bcc: 'bcc',
+    subject: 'subject',
+    body: 'body'
+  },
   gmail: {
     path: 'co',
     to: 'to',
     cc: 'cc',
     bcc: 'bcc',
+    subject: 'subject',
+    body: 'body'
+  },
+  spark: {
+    path: 'compose',
+    to: 'recipient',
     subject: 'subject',
     body: 'body'
   },
@@ -57,7 +73,14 @@ const uriParams = {
     bcc: 'bcc',
     subject: 'subject',
     body: 'htmlBody',
-  }
+  },
+  outlook: {
+    path: 'compose',
+    to: 'to',
+    subject: 'subject',
+    body: 'body'
+  },
+
 }
 
 /**
@@ -80,7 +103,8 @@ function getUrlParams(app, options) {
     return params;
   }, [])
   
-  return `${appParms['path']}?${urlParams.join('&')}`
+  const path = app === 'apple-mail' ? options['to'] : appParms['path'];
+  return `${path}?${urlParams.join('&')}`
 }
 
 /**
@@ -197,6 +221,11 @@ export async function openInbox(options = {}) {
   let params = '';
   if(options.to || options.subject || options.body) {
     params = getUrlParams(app, options);
+
+    if (app === 'apple-mail') {
+      // apple mail base url to compose an email is mailto
+      url = 'mailto:';
+    }
   }
 
   if (url) {

--- a/index.ios.js
+++ b/index.ios.js
@@ -4,36 +4,31 @@
  * This file supports both iOS and Android.
  */
 
-import { ActionSheetIOS, Linking } from "react-native";
-import { option } from "@oclif/parser/lib/flags";
+import { ActionSheetIOS, Linking } from 'react-native';
 
 class EmailException {
   constructor(message) {
     this.message = message;
-    this.name = "EmailException";
+    this.name = 'EmailException';
   }
 }
 
 const prefixes = {
-  "apple-mail": "message://",
-  gmail: "googlegmail://",
-  inbox: "inbox-gmail://",
-  spark: "readdle-spark://",
-  airmail: "airmail://",
-  outlook: "ms-outlook://",
-  yahoo: "ymail://",
-  superhuman: "superhuman://"
+  'apple-mail': 'message://',
+  gmail: 'googlegmail://',
+  inbox: 'inbox-gmail://',
+  spark: 'readdle-spark://',
+  airmail: 'airmail://',
+  outlook: 'ms-outlook://'
 };
 
 const titles = {
-  "apple-mail": "Mail",
-  gmail: "Gmail",
-  inbox: "Inbox",
-  spark: "Spark",
-  airmail: "Airmail",
-  outlook: "Outlook",
-  yahoo: "Yahoo Mail",
-  superhuman: "Superhuman"
+  'apple-mail': 'Mail',
+  gmail: 'Gmail',
+  inbox: 'Inbox',
+  spark: 'Spark',
+  airmail: 'Airmail',
+  outlook: 'Outlook'
 };
 
 /**
@@ -46,7 +41,7 @@ const titles = {
  *  - outlook: https://stackoverflow.com/questions/32369198/i-just-want-to-open-ms-outlook-app-and-see-mailto-screen-using-url-scheme-at-ios
  */
 const uriParams = {
-  "apple-mail": {
+  'apple-mail': {
     cc: 'cc',
     bcc: 'bcc',
     subject: 'subject',
@@ -150,9 +145,9 @@ export function isAppInstalled(app) {
  * @returns {Promise<String|null>}
  */
 export function askAppChoice(
-  title = "Open mail app",
-  message = "Which app would you like to open?",
-  cancelLabel = "Cancel",
+  title = 'Open mail app',
+  message = 'Which app would you like to open?',
+  cancelLabel = 'Cancel',
   removeText = false
 ) {
   return new Promise(async resolve => {
@@ -196,14 +191,14 @@ export function askAppChoice(
  * }} options 
  */
 async function getApp(options) {
-  if (options && typeof options !== "object") {
+  if (options && typeof options !== 'object') {
     throw new EmailException(
-      "First parameter must be an object of options."
+      'First parameter must be an object of options.'
     );
   }
 
   if (
-    "app" in options &&
+    'app' in options &&
     options.app &&
     Object.keys(prefixes).indexOf(options.app) < 0
   ) {

--- a/index.ios.js
+++ b/index.ios.js
@@ -36,12 +36,27 @@ const titles = {
   superhuman: "Superhuman"
 };
 
+/**
+ * Available params for each app url
+ *  - airmail: https://help.airmailapp.com/en-us/article/airmail-ios-url-scheme-1q060gy/
+ *  - gmail: https://stackoverflow.com/questions/32114455/open-gmail-app-from-my-app 
+ */
 const uriParams = {
   gmail: {
     path: 'co',
     to: 'to',
+    cc: 'cc',
+    bcc: 'bcc',
     subject: 'subject',
     body: 'body'
+  },
+  airmail: {
+    path: 'compose',
+    to: 'to',
+    cc: 'cc',
+    bcc: 'bcc',
+    subject: 'subject',
+    body: 'htmlBody',
   }
 }
 
@@ -58,7 +73,7 @@ function getUrlParams(app, options) {
   const appParms = uriParams[app];
   if (!appParms) { return "" };
 
-  const urlParams = ['to', 'subject', 'body'].reduce((params, currentParam) => {
+  const urlParams = Object.keys(appParms).reduce((params, currentParam) => {
     if (options[currentParam]) {
       params.push(`${appParms[currentParam]}=${options[currentParam]}`);
     }


### PR DESCRIPTION
# Goal
Being able to open the mail app to the compose screen and optionally provide `to`, `cc`, `bcc`, `subject` and `body`.

# State
It has only been implemented for iOS so far. I've tested it on my iPhone 7 device with Gmail and Apple Mail. It's working as expected.

# Whats new??
I added new attributes to the options argument of `openInbox()`.

| param | required | default | description |
| --- | --- | --- | --- |
|compose| no | `false` | When set to `true`, it will force the app to open on the compose screen even if you do not provide any of the following attributes: **to**, **cc**, **bcc**, **subject** or **body**. If you do provide at least one of these attributes, the app will by default be opened on the compose screen so no need to set this attribute to `true` in this case.|
| to | no | `undefined` | The email of the recipient. |
| cc | no |  `undefined` | The email of the cc. |
| bcc | no |  `undefined` | The email of the bcc. |
| subject | no |  `undefined` | The email subject. |
| body | no `undefined | The email body. |

# Remaining work
- [ ] Test if it is working with Inbox
- [ ] Test if it is working with Airmail
- [ ] Test if it is working with Spark (+ check if cc and bcc can be added as urlParams)
- [ ] Test if it is working with Outlook (+ check if cc and bcc can be added as urlParams)
- [ ] Implement the equivalent for Android

# Recordings

### Apple Mail
![apple-mail](https://user-images.githubusercontent.com/3688337/65659461-b3ecc480-dff9-11e9-9a54-9ab8295aa2f5.gif)

### Gmail
![gmail](https://user-images.githubusercontent.com/3688337/65659525-f4e4d900-dff9-11e9-87ca-7c5f7bcead8b.gif)




 
