### PR TITLE
Update the android project to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ yarn-error.log
 build/
 android/build/
 .DS_Store
+*.iml
+local.properties

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,36 +1,46 @@
 import groovy.json.JsonSlurper
 
-def computeVersionName() {
-    // dynamically retrieve version from package.json
+def readPackageJson() {
     def slurper = new JsonSlurper()
-    def json = slurper.parse(file('../package.json'), "utf-8")
-    return json.version
+    return slurper.parse(file('../package.json'), "utf-8")
 }
 
-def DEFAULT_COMPILE_SDK_VERSION             = 25
-def DEFAULT_BUILD_TOOLS_VERSION             = "25.0.3"
-def DEFAULT_TARGET_SDK_VERSION              = 25
+def computeVersionName() {
+    return readPackageJson().version
+}
+
+def computeVersionCode() {
+    return readPackageJson().versionCode
+}
 
 buildscript {
+    ext {
+        minSdkVersion = 16
+        compileSdkVersion = 29
+        targetSdkVersion = 29
+        gradlePluginVersion = "3.5.1"
+        reactNativeVersion = "+" // The react native versioning on jcenter is messed up: https://github.com/facebook/react-native/issues/13094
+    }
+
     repositories {
         jcenter()
+        google()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.+'
+        classpath "com.android.tools.build:gradle:${gradlePluginVersion}"
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
-    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
-        versionCode 1
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode computeVersionCode()
         versionName computeVersionName()
     }
 
@@ -45,8 +55,10 @@ repositories {
     maven {
         url "$projectDir/../../react-native/android"
     }
+    jcenter()
+    google()
 }
 
 dependencies {
-    implementation "com.facebook.react:react-native:+"
+    implementation "com.facebook.react:react-native:${rootProject.ext.reactNativeVersion}"
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jul 26 16:40:12 CEST 2018
+#Thu Oct 03 23:34:18 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/android/src/main/java/com/facebook/react/modules/email/EmailPackage.java
+++ b/android/src/main/java/com/facebook/react/modules/email/EmailPackage.java
@@ -1,6 +1,7 @@
 package com.facebook.react.modules.email;
 
 import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
@@ -26,4 +27,8 @@ public class EmailPackage implements ReactPackage {
     return modules;
   }
 
+  @Override
+  public List<Class<? extends JavaScriptModule>> createJSModules() {
+    return Collections.emptyList();
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "react-native-email-link",
   "version": "1.5.3",
+  "versionCode": 2,
   "description": "Open the mail app of the user's choice",
   "main": "index",
   "repository": {


### PR DESCRIPTION
I couldn't get the forked version of the repo to build in my pretty up-to-date android studio setup. So I went down the rabbit hole of cleaning up the build.gradle file to get it working. 

Resolves https://github.com/tschoffelen/react-native-email-link/issues/36

Additionally, I'm not 100% sure if this is the only thing needed for AndroidX support, but I at least updated the target version to 29: https://github.com/tschoffelen/react-native-email-link/issues/25