### PR TITLE
Android: add an optional param to start the activity in the current task

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ openInbox()
 - [`message`](#message)
 - [`cancelLabel`](#cancelLabel)
 - [`removeText`](#removeText)
+- [`newTask`](#newTask)
 
 ### `title`
 
@@ -91,6 +92,16 @@ If true, not text will be show above the ActionSheet or Intent. Default value is
 | Type     | Required | Default  |
 | -------- | -------- | -------- |
 | boolean  | No       | false    |
+
+### `newTask`
+
+If true, the email Intent will be started in a new Android task. Else, the Intent will be launched in the current task.
+
+Read more about Android tasks [here](https://developer.android.com/guide/components/activities/tasks-and-back-stack).
+
+| Type     | Required | Default   | Platform |
+| -------- | -------- | --------- | -------- |
+| boolean  | No       | true      | Android  |
 
 
 ## Authors

--- a/android/src/main/java/com/facebook/react/modules/email/EmailModule.java
+++ b/android/src/main/java/com/facebook/react/modules/email/EmailModule.java
@@ -1,21 +1,19 @@
 package com.facebook.react.modules.email;
 
-import com.facebook.react.bridge.NativeModule;
-import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.bridge.ReactContextBaseJavaModule;
-import com.facebook.react.bridge.ReactMethod;
-
 import android.content.Intent;
 import android.content.pm.LabeledIntent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
 
-import java.util.Map;
-import java.util.HashMap;
-import java.util.List;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
 import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nullable;
 
 public class EmailModule extends ReactContextBaseJavaModule {
 
@@ -29,7 +27,7 @@ public class EmailModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void open(final String title) {
+  public void open(final String title, final boolean newTask) {
     Intent emailIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("mailto:"));
     PackageManager pm = getCurrentActivity().getPackageManager();
 
@@ -38,7 +36,7 @@ public class EmailModule extends ReactContextBaseJavaModule {
         ResolveInfo ri = resInfo.get(0);
         // First create an intent with only the package name of the first registered email app
         // and build a picked based on it
-        Intent intentChooser = pm.getLaunchIntentForPackage(ri.activityInfo.packageName);
+        Intent intentChooser = createLaunchIntent(ri, newTask);
 
         if (intentChooser != null) {
           Intent openInChooser = Intent.createChooser(intentChooser, title);
@@ -49,7 +47,7 @@ public class EmailModule extends ReactContextBaseJavaModule {
               // Extract the label and repackage it in a LabeledIntent
               ri = resInfo.get(i);
               String packageName = ri.activityInfo.packageName;
-              Intent intent = pm.getLaunchIntentForPackage(packageName);
+              Intent intent = createLaunchIntent(ri, newTask);
 
               if (intent != null) {
                 intentList.add(new LabeledIntent(intent, packageName, ri.loadLabel(pm), ri.icon));
@@ -59,9 +57,30 @@ public class EmailModule extends ReactContextBaseJavaModule {
           LabeledIntent[] extraIntents = intentList.toArray(new LabeledIntent[intentList.size()]);
           // Add the rest of the email apps to the picker selection
           openInChooser.putExtra(Intent.EXTRA_INITIAL_INTENTS, extraIntents);
-          openInChooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+          setNewTaskFlag(openInChooser, newTask);
           getCurrentActivity().startActivity(openInChooser);
         }
+      }
+  }
+
+  @Nullable
+  private Intent createLaunchIntent(final ResolveInfo resolveInfo, final boolean newTask) {
+      PackageManager packageManager = getCurrentActivity().getPackageManager();
+      Intent launchIntent = packageManager.getLaunchIntentForPackage(resolveInfo.activityInfo.packageName);
+      if (launchIntent != null) {
+        // getLaunchIntentForPackage internally adds the FLAG_ACTIVITY_NEW_TASK.
+        // See: https://github.com/aosp-mirror/platform_frameworks_base/blob/master/core/java/android/app/ApplicationPackageManager.java#L233
+        // So if we want to remove it, we must explicitly unset it.
+        setNewTaskFlag(launchIntent, newTask);
+      }
+      return launchIntent;
+  }
+
+  private void setNewTaskFlag(final Intent intent, final boolean newTask) {
+      if (newTask) {
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      } else {
+        intent.setFlags(intent.getFlags() & ~Intent.FLAG_ACTIVITY_NEW_TASK);
       }
   }
 }

--- a/index.android.js
+++ b/index.android.js
@@ -29,6 +29,11 @@ export async function openInbox(options = {}) {
     text = '';
   }
 
-  NativeModules.Email.open(text);
+  let newTask = true;
+  if ("newTask" in options) {
+    newTask = Boolean(options.newTask);
+  }
+
+  NativeModules.Email.open(text, newTask);
   return;
 }


### PR DESCRIPTION
Adds an optional param `newTask` for the Android version of the API. Setting it explicitly to `false` will start the activity in the current Android task. It's an optional param, with a default value of `true`.

Resolves https://github.com/leanmotherfuckers/react-native-email-link/issues/29

Attempt 2 for https://github.com/tschoffelen/react-native-email-link/pull/30