### PR TITLE
Latest release failing on Android because reactNativeVersion not found

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,6 +13,10 @@ def computeVersionCode() {
     return readPackageJson().versionCode
 }
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 buildscript {
     ext {
         minSdkVersion = 16
@@ -60,5 +64,5 @@ repositories {
 }
 
 dependencies {
-    implementation "com.facebook.react:react-native:${rootProject.ext.reactNativeVersion}"
+    implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
 }


### PR DESCRIPTION
The latest version of the library is failing to build on Android with the following error:

`Cannot get property 'reactNativeVersion' on extra properties extension as it does not exist`

This PR fixes that by having a safeExtGet, where if `reactNativeVersion` is present it will take that and `+` otherwise