### PR TITLE
Remove override of createJSModules

### DIFF
--- a/android/src/main/java/com/facebook/react/modules/email/EmailPackage.java
+++ b/android/src/main/java/com/facebook/react/modules/email/EmailPackage.java
@@ -27,7 +27,6 @@ public class EmailPackage implements ReactPackage {
     return modules;
   }
 
-  @Override
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
This PR removes the Override in on the `createJSModules` call. For more information: https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8

I have tested and everything works fine on RNv0.61.2. 