### PR TITLE
Add compatibility with yahoo and superhuman

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -9,25 +9,25 @@ import { EmailException } from './src/email-exception';
 export { EmailException };
 
 const prefixes = {
-  "apple-mail": "message://",
-  gmail: "googlegmail://",
-  inbox: "inbox-gmail://",
-  spark: "readdle-spark://",
-  airmail: "airmail://",
-  outlook: "ms-outlook://",
-  yahoo: "ymail://",
-  superhuman: "superhuman://"
+  'apple-mail': 'message://',
+  gmail: 'googlegmail://',
+  inbox: 'inbox-gmail://',
+  spark: 'readdle-spark://',
+  airmail: 'airmail://',
+  outlook: 'ms-outlook://',
+  yahoo: 'ymail://',
+  superhuman: 'superhuman://'
 };
 
 const titles = {
-  "apple-mail": "Mail",
-  gmail: "Gmail",
-  inbox: "Inbox",
-  spark: "Spark",
-  airmail: "Airmail",
-  outlook: "Outlook",
-  yahoo: "Yahoo Mail",
-  superhuman: "Superhuman"
+  'apple-mail': 'Mail',
+  gmail: 'Gmail',
+  inbox: 'Inbox',
+  spark: 'Spark',
+  airmail: 'Airmail',
+  outlook: 'Outlook',
+  yahoo: 'Yahoo Mail',
+  superhuman: 'Superhuman'
 };
 
 /**

--- a/index.ios.js
+++ b/index.ios.js
@@ -9,21 +9,25 @@ import { EmailException } from './src/email-exception';
 export { EmailException };
 
 const prefixes = {
-  'apple-mail': 'message://',
-  gmail: 'googlegmail://',
-  inbox: 'inbox-gmail://',
-  spark: 'readdle-spark://',
-  airmail: 'airmail://',
-  outlook: 'ms-outlook://'
+  "apple-mail": "message://",
+  gmail: "googlegmail://",
+  inbox: "inbox-gmail://",
+  spark: "readdle-spark://",
+  airmail: "airmail://",
+  outlook: "ms-outlook://",
+  yahoo: "ymail://",
+  superhuman: "superhuman://"
 };
 
 const titles = {
-  'apple-mail': 'Mail',
-  gmail: 'Gmail',
-  inbox: 'Inbox',
-  spark: 'Spark',
-  airmail: 'Airmail',
-  outlook: 'Outlook'
+  "apple-mail": "Mail",
+  gmail: "Gmail",
+  inbox: "Inbox",
+  spark: "Spark",
+  airmail: "Airmail",
+  outlook: "Outlook",
+  yahoo: "Yahoo Mail",
+  superhuman: "Superhuman"
 };
 
 /**


### PR DESCRIPTION
[This PR](https://github.com/tschoffelen/react-native-email-link/pull/31) removed compatibility with those two email clients. In case that was done by mistake, this tries to bring it back.