### PR TITLE
Update function declarations to support async/await

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ export function openInbox({
   message?: string;
   cancelLabel?: string;
   removeText?: boolean;
-}): void;
+}): Promise<void>;
 
 export function openComposer({
   app,
@@ -34,7 +34,7 @@ export function openComposer({
   bcc?: string;
   subject?: string;
   body?: string;
-}): void;
+}): Promise<void>;
 
 export class EmailException {
   message: string;


### PR DESCRIPTION
The implementation of both `openInbox` and `openComposer` are `async`, which means the function returns a promise (not `void`). This PR corrects the typescript definitions of these functions, so Typescript projects that consume this library can call `await openInbox({ ... })` without getting warned by the transpiler or linter.