### PR TITLE
have EmailException extend Error

### DIFF
--- a/src/email-exception.js
+++ b/src/email-exception.js
@@ -1,4 +1,4 @@
-export class EmailException {
+export class EmailException extends Error {
   constructor(message) {
     this.message = message;
     this.name = 'EmailException';


### PR DESCRIPTION
Have the EmailException extend Error, so that for example Sentry recognises these errors.

Fixes https://github.com/tschoffelen/react-native-email-link/issues/63

Related: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Custom_Error_Types