### PR TITLE
Handle cancellation by throwing with a different message

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -180,7 +180,7 @@ export function askAppChoice(
       },
       buttonIndex => {
         if (buttonIndex === options.length - 1) {
-          return resolve(null);
+          return resolve('cancel');
         }
         return resolve(availableApps[buttonIndex]);
       }
@@ -220,6 +220,10 @@ async function getApp(options) {
   if (!app) {
     const { title, message, cancelLabel, removeText } = options;
     app = await askAppChoice(title, message, cancelLabel, removeText);
+  }
+
+  if (app === 'cancel') {
+    throw new EmailException('User cancelled');
   }
 
   if (!app) {


### PR DESCRIPTION
## Summary

This PR updates handling of selecting the "cancel" option.

---

Currently, when selecting "cancel" the `No email app found` exception is triggered - which means it's difficult to know if user has cancelled or doesn't have an email app.

I here propose throwing an exception with a `User cancelled` message, so we can catch it when using `openInbox()` :)

**Note:** I haven't been able to test on Android, but as it's using `NativeModules.Email.open()` I guess it's not relevant there? 

This closes #52