### PR TITLE
Properly initialize the Error class when throwing EmailException

### DIFF
--- a/src/email-exception.js
+++ b/src/email-exception.js
@@ -1,6 +1,6 @@
 export class EmailException extends Error {
   constructor(message) {
-    this.message = message;
+    super(message);
     this.name = 'EmailException';
   }
 }


### PR DESCRIPTION
Now that `EmailException` extends the `Error` class (as per #64), we have to properly initialize `Error`. Otherwise, when you try to throw `EmailException` you end up with `TypeError: undefined is not an object (evaluating '_this.message = message')`.