### PR TITLE
Add params for Superhuman

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -93,6 +93,14 @@ const uriParams = {
     bcc: 'bcc',
     subject: 'subject',
     body: 'body'
+  },
+  superhuman: {
+    path: 'compose',
+    to: 'to',
+    cc: 'cc',
+    bcc: 'bcc',
+    subject: 'subject',
+    body: 'body'
   }
 }
 


### PR DESCRIPTION
Noticed that these were missing which would cause Superhuman to just open to the inbox even if you called `openComposer`. Tested each of these params and they work as expected with Superhuman.