### PR TITLE
Return the email app that was selected or null

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ export function openInbox({
   message?: string;
   cancelLabel?: string;
   removeText?: boolean;
-}): Promise<void>;
+}): Promise<{ app: string; title: string; } | null>;
 
 export function openComposer({
   app,
@@ -34,7 +34,7 @@ export function openComposer({
   bcc?: string;
   subject?: string;
   body?: string;
-}): Promise<void>;
+}): Promise<{ app: string; title: string; } | null>;
 
 export class EmailException {
   message: string;

--- a/index.ios.js
+++ b/index.ios.js
@@ -165,8 +165,10 @@ export function askAppChoice(
       }
     }
 
-    if (availableApps.length < 2) {
-      return resolve(availableApps[0] || null);
+    if (!availableApps.length) {
+      throw new EmailException('No email apps available');
+    } else if (availableApps.length === 1) {
+      return resolve(availableApps[0]);
     }
 
     let options = availableApps.map(app => titles[app]);
@@ -191,7 +193,7 @@ export function askAppChoice(
 }
 
 /**
- * Returns the name of the app provided in the options object of the app selected by the user.
+ * Returns the name of the app provided in the options object or the app selected by the user.
  * @param {{
  *     app: string | undefined | null,
  * }} options 
@@ -222,10 +224,6 @@ async function getApp(options) {
     app = await askAppChoice(title, message, cancelLabel, removeText);
   }
 
-  if (!app) {
-    throw new EmailException('No email app found');
-  }
-
   return app;
 }
 
@@ -242,7 +240,13 @@ async function getApp(options) {
   */
 export async function openInbox(options = {}) {
   const app = await getApp(options);
-  return Linking.openURL(prefixes[app]);
+
+  if (!app) {
+    return null
+  }
+
+  await Linking.openURL(prefixes[app]);
+  return { app, title: titles[app] };
 }
 
 /**
@@ -263,6 +267,11 @@ export async function openInbox(options = {}) {
   */
 export async function openComposer(options) {
   const app = await getApp(options);
+
+  if (!app) {
+    return null
+  }
+
   const params = getUrlParams(app, options);
   let prefix = prefixes[app];
 
@@ -271,5 +280,6 @@ export async function openComposer(options) {
     prefix = 'mailto:';
   }
 
-  return Linking.openURL(`${prefix}${params}`);
+  await Linking.openURL(`${prefix}${params}`);
+  return { app, title: titles[app] };
 }


### PR DESCRIPTION
This provides apps with more information and enables them to offer user flows like remembering choices for next time. Fixes #52 by returning `null` if the user canceled, but still correctly throwing an error if there's an issue.