### PR TITLE
Make passed object parameter optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ export function openInbox({
   message,
   cancelLabel,
   removeText,
-}: {
+}?: {
   app?: string | null;
   title?: string;
   message?: string;
@@ -23,7 +23,7 @@ export function openComposer({
   bcc,
   subject,
   body,
-}: {
+}?: {
   app?: string | null;
   title?: string;
   message?: string;


### PR DESCRIPTION
The documentation shows usage of these without a passed object param. This is a correction to support that usage with TypeScript. I have tested this locally without issue.