### PR TITLE
Properly extend Error base class

### DIFF
--- a/src/email-exception.js
+++ b/src/email-exception.js
@@ -1,4 +1,4 @@
-export class EmailException {
+export class EmailException extends Error {
   constructor(message) {
     this.message = message;
     this.name = 'EmailException';

--- a/src/email-exception.js
+++ b/src/email-exception.js
@@ -1,6 +1,6 @@
 export class EmailException extends Error {
-  constructor(message) {
-    this.message = message;
+  constructor(...params) {
+    super(...params)
     this.name = 'EmailException';
   }
 }


### PR DESCRIPTION
Make sure we pass on all parameters to the Error base class (such as line number and filename)

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#ES5_Custom_Error_Object
